### PR TITLE
Added new command to pull random image via keywords fron Unsplash API

### DIFF
--- a/Modules/Hacktoberfest/Hacktoberfest.cs
+++ b/Modules/Hacktoberfest/Hacktoberfest.cs
@@ -1,16 +1,15 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Discord;
-using Discord.Commands;
-using Discord.WebSocket;
-using Justibot.Services;
-using System.Web;
 using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using System.Web;
+using Discord.Commands;
+using Justibot.Services;
+using justibot_server.Modules.Hacktoberfest.Model;
 using justibot_server.Modules.OpenWeather;
 using RestSharp;
-using justibot_server.Modules.Hacktoberfest.Model;
 
 namespace Justibot.Modules.Help
 {
@@ -283,6 +282,25 @@ namespace Justibot.Modules.Help
 
             await ReplyAsync(response.setup);
             await ReplyAsync(response.punchline);
+        }
+
+        [Command("Image")]
+        [Summary("Get a random image keywords.")]
+        public async Task GetRandomImage([Remainder] string keywords)
+        {
+            if (string.IsNullOrWhiteSpace(keywords))
+            {
+                await ReplyAsync("Sorry, to get an image you have to pass in a space delimited listed of keywords.");
+            }
+
+            var request = (HttpWebRequest)WebRequest.Create($"https://source.unsplash.com/featured/?{string.Join(",", keywords!.Split(' '))}");
+            request.Method = "GET";
+            request.AllowAutoRedirect = true;
+            request.ContentType = "application/x-www-form-urlencoded";
+
+            var response = request.GetResponse();
+
+            await ReplyAsync(response.ResponseUri.ToString());
         }
     }
 }


### PR DESCRIPTION
Always fun to search for a random image given a set of keywords.

**Command Syntax:**

BotPrefix image random list of keywords

**Example Usage:**

BotPrefix image pizza
BotPrefix image pizza party

**Example Responses:**

![image](https://user-images.githubusercontent.com/7233525/95645810-4be41180-0a88-11eb-93f1-2f7db35d5f72.png)
![image](https://user-images.githubusercontent.com/7233525/95645816-6322ff00-0a88-11eb-9305-d2d0146736df.png)

**Bad Image Response**

BotPrefix image dasfasfdasdfasdf

![image](https://user-images.githubusercontent.com/7233525/95645849-91084380-0a88-11eb-8f7c-f35dfdd8e8b4.png)

Related to #25 